### PR TITLE
Fix green detection variable names

### DIFF
--- a/utils/PI5_LeafDetection.py
+++ b/utils/PI5_LeafDetection.py
@@ -7,8 +7,8 @@ def detect_green_color(image):
     # Convert image to HSV color space for easier color detection
     hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
     # Define range of green color in HSV
-    lower_orange = np.array([44, 100, 100])
-    upper_orange = np.array([86, 255, 255])
+    lower_green = np.array([44, 100, 100])
+    upper_green = np.array([86, 255, 255])
     # Threshold the HSV image to get only green colors
     mask = cv2.inRange(hsv_image, lower_green, upper_green)
     # Check if there is any green in the frame


### PR DESCRIPTION
## Summary
- rename orange color variable names to `lower_green` and `upper_green`
- keep `cv2.inRange` consistent with the new names

## Testing
- `python -m py_compile utils/PI5_LeafDetection.py`
- ❌ `python - <<'PY'
import utils.PI5_LeafDetection as pld
import numpy as np
print(pld.detect_green_color(np.zeros((10,10,3), dtype=np.uint8)))
PY` *(fails: ModuleNotFoundError: No module named 'picamera2')*

------
https://chatgpt.com/codex/tasks/task_e_6862498222fc8322a70da40437cec349